### PR TITLE
storing config in dynamodb table poc

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -103,6 +103,29 @@ async function saveParamsFile(config) {
   }
 }
 
+async function getSharedConfigByService (config) {
+  const { service, env } = config
+
+  console.log(chalk.green(`Getting parameters from Config Table  environment: "${env}" service: "${service}"`))
+
+  const results = await configWrapper.awsManager.getSharedConfigByService(env, service)
+
+  console.log(`Parameters under environment: "${env}" service: "${service}"\n`, JSON.stringify(results, null, 2))
+}
+
+async function putSharedConfigFromFile (config) {
+  const { infile, env, service } = config
+  console.log(chalk.green(`Reading params from file: ${infile}`))
+  const data = await fs.readFile(infile, 'utf8')
+
+  // Parse the JSON data
+  const jsonData = JSON.parse(data)
+
+  console.log(chalk.green(`Saving parameters to Config Table  environment: "${env}" service: "${service}"`))
+  await configWrapper.awsManager.putSharedConfigRecordsByService(jsonData, env, service)
+  console.log(chalk.green(`Saved parameters to Config Table  "environment ${env}" service: "${service}"`))
+}
+
 async function putToAWSFromFile(config) {
   const { infile, env, service, overwrite, encrypt } = config
   console.log(chalk.green(`Reading params from file: ${infile}`))
@@ -221,6 +244,50 @@ async function promptForMissingOptions(options) {
           name: 'service',
           message: 'Service: ',
           default: '',
+        })
+      }
+      break
+    }
+    case 'getSharedConfigByService': {
+      commandFunc = getSharedConfigByService
+
+      if (!options.env) {
+        questions.push({
+          type: 'input',
+          name: 'env',
+          message: 'Environment: ',
+          default: 'devevelop'
+        })
+      }
+
+      if (!options.service) {
+        questions.push({
+          type: 'input',
+          name: 'service',
+          message: 'Service: ',
+          default: ''
+        })
+      }
+      break
+    }
+    case 'putSharedConfigFromFile': {
+      commandFunc = putSharedConfigFromFile
+
+      if (!options.env) {
+        questions.push({
+          type: 'input',
+          name: 'env',
+          message: 'Environment: ',
+          default: 'devevelop'
+        })
+      }
+
+      if (!options.service) {
+        questions.push({
+          type: 'input',
+          name: 'service',
+          message: 'Service: ',
+          default: ''
         })
       }
       break

--- a/src/lib/awsManager.js
+++ b/src/lib/awsManager.js
@@ -141,6 +141,31 @@ async function getSharedConfigByService (env, service) {
   return convertedParams
 }
 
+async function putSharedConfigRecordsByService (fileObj, env, service) {
+  if (!configTable) {
+    configTable = await getParameter(env, 'common', 'DYNAMODB_CONFIG_TABLE', true)
+  }
+
+  for (const key in fileObj) {
+    if (!fileObj[key].value) {
+      console.log(`Skipping ${key} no value provided.`)
+      continue
+    }
+    const params = {
+      TableName: configTable.value,
+      Item: {
+        name: key,
+        service,
+        value: fileObj[key].value
+      }
+    }
+
+    console.log('Create Config record params', JSON.stringify(params, null, 2))
+
+    await docClient.put(params).promise()
+  }
+}
+
 // TODO: add param caching 
 // TODO: add support for labels
 
@@ -278,6 +303,7 @@ module.exports = {
   getParameter,
   getParametersByService,
   getSharedConfigByService,
+  putSharedConfigRecordsByService,
   setParameter,
   setParametersByService,
   getEnvironments,


### PR DESCRIPTION
https://github.com/opentorc/torc-serverless/issues/557

This PR is a POC for storing config parameters in Config table related PR https://github.com/opentorc/platform-api/pull/1133  added two methods to the cli to be able to test it. 

1. Create Config table mentioned in the related PR

1. install `config-wrapper`  package locally `npm i  path../.../config-wrapper`

2. create `sharedConfig.json`
 eg
  ```json
  {
    "DYNAMODB_USER_TABLE_STREAM": {
        "value": "TABLE_NAME"
    },
    "ASSESSMENT_CONFIG": {
       "value":  {
                "testId": 123459,
                "valir": false
       }
    },
    "ARRAY_CONFIG" : {
      "value": [{
        "testValue" : 5
      }]
    }
  }
  ```
  
  5. with the cli create service the parameters `config-wrapper putSharedConfigFromFile --infile sharedConfig.json --env develop --service resolvers`
  
  6. with the cli get service parameters `config-wrapper getSharedConfigByService --env develop --service resolvers`